### PR TITLE
added various options and new formatting

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ var Username string
 var Token string
 var LastWeek bool
 var ThisWeek bool
+var Today bool
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -29,6 +30,8 @@ var rootCmd = &cobra.Command{
 			StartDate, EndDate = utils.GetLastWeekDates()
 		} else if ThisWeek == true {
 			StartDate, EndDate = utils.GetThisWeekDates()
+		} else if Today == true {
+			StartDate, EndDate = utils.GetTodayDates()
 		}
 
 		return github.GetGithubActivity(Domain, StartDate, EndDate, Username, Token)
@@ -49,7 +52,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&StartDate, "start", "s", utils.GetDefaultStartDate(), "Collect activities starting on this date")
 	rootCmd.PersistentFlags().StringVarP(&EndDate, "end", "e", utils.GetDefaultEndDate(), "Collect activities up to this date")
 	rootCmd.PersistentFlags().BoolVarP(&LastWeek, "last-week", "l", false, "Collect activities for last week (last week Monday to last week Friday")
-	rootCmd.PersistentFlags().BoolVarP(&ThisWeek, "this-week", "n", false, "Collect activities for this week (Monday to Friday")
+	rootCmd.PersistentFlags().BoolVarP(&ThisWeek, "this-week", "w", false, "Collect activities for this week (Monday to Friday")
+	rootCmd.PersistentFlags().BoolVarP(&Today, "today", "n", false, "Collect activities for today")
 	rootCmd.PersistentFlags().StringVarP(&Username, "user", "u", utils.GetCurrentUsername(), "Username")
 	rootCmd.PersistentFlags().StringVarP(&Token, "token", "t", "", "Github Personal Access Token (default `$GITHUB_TOKEN`)")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,8 @@ var StartDate string
 var EndDate string
 var Username string
 var Token string
+var LastWeek bool
+var ThisWeek bool
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -23,6 +25,12 @@ var rootCmd = &cobra.Command{
 	Short: "Get your Github activity",
 	Long:  `Get PRs, reviews, and issues created during a specific time interval.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if LastWeek == true {
+			StartDate, EndDate = utils.GetLastWeekDates()
+		} else if ThisWeek == true {
+			StartDate, EndDate = utils.GetThisWeekDates()
+		}
+
 		return github.GetGithubActivity(Domain, StartDate, EndDate, Username, Token)
 	},
 }
@@ -40,6 +48,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&Domain, "domain", "d", "github.com", "Github domain")
 	rootCmd.PersistentFlags().StringVarP(&StartDate, "start", "s", utils.GetDefaultStartDate(), "Collect activities starting on this date")
 	rootCmd.PersistentFlags().StringVarP(&EndDate, "end", "e", utils.GetDefaultEndDate(), "Collect activities up to this date")
+	rootCmd.PersistentFlags().BoolVarP(&LastWeek, "last-week", "l", false, "Collect activities for last week (last week Monday to last week Friday")
+	rootCmd.PersistentFlags().BoolVarP(&ThisWeek, "this-week", "n", false, "Collect activities for this week (Monday to Friday")
 	rootCmd.PersistentFlags().StringVarP(&Username, "user", "u", utils.GetCurrentUsername(), "Username")
 	rootCmd.PersistentFlags().StringVarP(&Token, "token", "t", "", "Github Personal Access Token (default `$GITHUB_TOKEN`)")
 }

--- a/pkg/github/helpers.go
+++ b/pkg/github/helpers.go
@@ -163,7 +163,7 @@ func printActivityOutput(userActivity *gitHubActivity) {
 	data := userActivity.Data.User.ContributionsCollection
 
 	if len(data.PullRequestContributions.Edges) > 0 {
-		fmt.Println("Pull Requests")
+		fmt.Println(fmt.Sprintf("Pull Requests (%d)", len(data.PullRequestContributions.Edges)))
 
 		// Assisted by watsonx Code Assistant
 		prOutput := make(map[string][]map[string]interface{})
@@ -191,7 +191,7 @@ func printActivityOutput(userActivity *gitHubActivity) {
 	}
 
 	if len(data.PullRequestReviewContributions.Edges) > 0 {
-		fmt.Println("Reviews")
+		fmt.Println(fmt.Sprintf("Reviews (%d)", len(data.PullRequestReviewContributions.Edges)))
 
 		// Assisted by watsonx Code Assistant
 		reviewOutput := make(map[string][]map[string]interface{})
@@ -219,7 +219,7 @@ func printActivityOutput(userActivity *gitHubActivity) {
 	}
 
 	if len(data.IssueContributions.Edges) > 0 {
-		fmt.Println("Issues")
+		fmt.Println(fmt.Sprintf("Issues (%d)", len(data.IssueContributions.Edges)))
 
 		// Assisted by watsonx Code Assistant
 		issueOutput := make(map[string][]map[string]interface{})

--- a/pkg/github/helpers.go
+++ b/pkg/github/helpers.go
@@ -246,4 +246,6 @@ func printActivityOutput(userActivity *gitHubActivity) {
 		}
 
 	}
+
+	fmt.Printf(fmt.Sprintf("\nTotals: PRs(%d) Reviews(%d) Issues(%d)", len(data.PullRequestContributions.Edges), len(data.PullRequestReviewContributions.Edges), len(data.IssueContributions.Edges)))
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -56,7 +56,7 @@ func GetLastWeekDates() (string, string) {
 	}
 
 	lastMonday := now.AddDate(0, 0, -daysToSubtract)
-	lastFriday := lastMonday.Add(7 * 24 * time.Hour)
+	lastFriday := lastMonday.Add(5 * 24 * time.Hour)
 
     lastMonday = time.Date(lastMonday.Year(), lastMonday.Month(), lastMonday.Day(), 0, 0, 0, 0, lastMonday.Location())
     lastFriday = time.Date(lastFriday.Year(), lastFriday.Month(), lastFriday.Day(), 0, 0, 0, 0, lastFriday.Location())

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -22,6 +22,41 @@ func GetDefaultEndDate() string {
 	return time.Now().In(time.Local).AddDate(0, 0, 1).Format("2006-01-02")
 }
 
+func GetThisWeekDates() (string, string) {
+	now := time.Now()
+	weekday := time.Duration(now.Weekday())
+	if weekday == 0 {
+		weekday = 7
+	}
+	thisMonday := now.Add(-1 * (weekday - 1) * 24 * time.Hour)
+	thisFriday := thisMonday.Add(7 * 24 * time.Hour)
+
+    thisMonday = time.Date(thisMonday.Year(), thisMonday.Month(), thisMonday.Day(), 0, 0, 0, 0, thisMonday.Location())
+    thisFriday = time.Date(thisFriday.Year(), thisFriday.Month(), thisFriday.Day(), 0, 0, 0, 0, thisFriday.Location())
+
+	return thisMonday.Format("2006-01-02"), thisFriday.Format("2006-01-02")
+}
+
+func GetLastWeekDates() (string, string) {
+	now := time.Now()
+	weekday := now.Weekday()
+	daysToSubtract := 0
+
+	if weekday == time.Sunday {
+		daysToSubtract = 6
+	} else {
+		daysToSubtract = int(weekday) - int(time.Monday) + 7
+	}
+
+	lastMonday := now.AddDate(0, 0, -daysToSubtract)
+	lastFriday := lastMonday.Add(7 * 24 * time.Hour)
+
+    lastMonday = time.Date(lastMonday.Year(), lastMonday.Month(), lastMonday.Day(), 0, 0, 0, 0, lastMonday.Location())
+    lastFriday = time.Date(lastFriday.Year(), lastFriday.Month(), lastFriday.Day(), 0, 0, 0, 0, lastFriday.Location())
+
+	return lastMonday.Format("2006-01-02"), lastFriday.Format("2006-01-02")
+}
+
 func FormatDate(input string) (string, error) {
 	layout := "2006-01-02"
 	t, err := time.Parse(layout, input)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -36,7 +36,7 @@ func GetThisWeekDates() (string, string) {
 		weekday = 7
 	}
 	thisMonday := now.Add(-1 * (weekday - 1) * 24 * time.Hour)
-	thisFriday := thisMonday.Add(7 * 24 * time.Hour)
+	thisFriday := thisMonday.Add(5 * 24 * time.Hour)
 
     thisMonday = time.Date(thisMonday.Year(), thisMonday.Month(), thisMonday.Day(), 0, 0, 0, 0, thisMonday.Location())
     thisFriday = time.Date(thisFriday.Year(), thisFriday.Month(), thisFriday.Day(), 0, 0, 0, 0, thisFriday.Location())

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -22,6 +22,13 @@ func GetDefaultEndDate() string {
 	return time.Now().In(time.Local).AddDate(0, 0, 1).Format("2006-01-02")
 }
 
+func GetTodayDates() (string, string) {
+	now := time.Now()
+	start := now.In(time.Local).Format("2006-01-02")
+	end := now.In(time.Local).AddDate(0,now.Hour(), 0).Format("2006-01-02")
+	return start, end
+}
+
 func GetThisWeekDates() (string, string) {
 	now := time.Now()
 	weekday := time.Duration(now.Weekday())


### PR DESCRIPTION
Make it easy to get today, this week, and last week activities:

```bash
github-activity --last-week
```

and

```bash
github-activity --this-week
```
and

```bash
github-activity --today
```

Also added improvement to summary print the count of total PRs, Reviews, and Issues.

```bash
➜  github-activity git:(main) ./github-activity --this-week
github.com activity for maximilien between 2025-03-24T00:00:00Z and 2025-03-31T00:00:00Z:

Pull Requests (5)
* i-am-bee/beeai-labs
    - feature: Issue #297 loop sequenceDiagram: https://github.com/i-am-bee/beeai-labs/pull/346
    - feature: adds parallel sequenceDiagram: https://github.com/i-am-bee/beeai-labs/pull/343
    - fixes issue #339: https://github.com/i-am-bee/beeai-labs/pull/340
    - fixes issues #337: https://github.com/i-am-bee/beeai-labs/pull/338
* psschwei/github-activity
    - added various options and new formatting: https://github.com/psschwei/github-activity/pull/2
Reviews (3)
* i-am-bee/beeai-labs
    - fixing default prompt issue: https://github.com/i-am-bee/beeai-labs/pull/347
    - option for default prompt: https://github.com/i-am-bee/beeai-labs/pull/345
    - fixed newline error: https://github.com/i-am-bee/beeai-labs/pull/342
Issues (2)
* i-am-bee/beeai-labs
    - bug: add new line between agent executions: https://github.com/i-am-bee/beeai-labs/issues/339
    - feature: change MockAgent output emoji to distinguish with BeeAI agents: https://github.com/i-am-bee/beeai-labs/issues/337
```
This makes it easy to get at a glance the total numbers.

Assuming your $GITHUB_TOKEN is set and your username matches your current shell $USERNAME