### PR TITLE
Add API for getting PR and Issue data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ gha*
 
 # Added by goreleaser init:
 dist/
+
+.idea

--- a/README.md
+++ b/README.md
@@ -14,15 +14,26 @@ Get PRs, reviews, and issues created during a specific time interval.
 
 Usage:
   gha [flags]
+  gha [command]
+
+Available Commands:
+  completion  Generate the autocompletion script for the specified shell
+  help        Help about any command
+  issues      Get GitHub Issues data
+  prs         Get PR data
 
 Flags:
-  -d, --domain string   Github domain (default "github.com")
-  -e, --end string      Collect activities up to this date (default "2025-03-11")
-  -h, --help            help for github-activity
-  -s, --start string    Collect activities starting on this date (default "2025-03-04")
-  -t, --token string    Github Personal Access Token (default $GITHUB_TOKEN)
-  -u, --user string     Username (default "paulschw")
+  -d, --domain string         Github domain (default "github.com")
+  -e, --end string            Collect activities up to this date (default "2025-03-11")
+  -h, --help                  help for github-activity
+  -l, --last-week             Collect activities for last week (last week Monday to last week Friday)
+  -s, --start string          Collect activities starting on this date (default "2025-03-04")
+  -w, --this-week             Collect activities for this week (Monday to Friday)
+  -n, --today                 Collect activities for today
+  -t, --token $GITHUB_TOKEN   Github Personal Access Token (default $GITHUB_TOKEN)
+  -u, --user string           Username (default "paulschw")
 
+Use "github-activity [command] --help" for more information about a command.
 ```
 
 The utility will then retrieve the GitHub activity for the specified user and print it to the console.
@@ -39,25 +50,21 @@ Here is an example of the output that the script might produce:
 
 ```
 $ ./gha -s 2025-03-01 -u psschwei
-Github Activity for psschwei on github.com between 2025-03-01T00:00:00Z and 2025-03-11T00:00:00Z:
+github.com activity for psschwei between 2025-03-01T00:00:00Z and 2025-03-11T00:00:00Z:
 
-Pull Requests
-repo:  i-am-bee/beeai
-title: feat(agents): add open deep research agent
-url:   https://github.com/i-am-bee/beeai/pull/253
+Pull Requests (1)
+*  i-am-bee/beeai
+    - feat(agents): add open deep research agent: https://github.com/i-am-bee/beeai/pull/253
 
-Reviews
-repo:  i-am-bee/beeai-labs
-title: first version of Workflow::to_mermaid method
-url:   https://github.com/i-am-bee/beeai-labs/pull/296
+Reviews (3)
+* i-am-bee/beeai-labs
+    - first version of Workflow::to_mermaid method: https://github.com/i-am-bee/beeai-labs/pull/296
 
-repo:  i-am-bee/beeai
-title: feat(agents): add open deep research agent
-url:   https://github.com/i-am-bee/beeai/pull/253
+* i-am-bee/beeai
+    - feat(agents): add open deep research agent: https://github.com/i-am-bee/beeai/pull/253
 
-repo:  i-am-bee/beeai-labs
-title: adding contributing guidelines for demo
-url:   https://github.com/i-am-bee/beeai-labs/pull/283
+* i-am-bee/beeai-labs
+    - adding contributing guidelines for demo: https://github.com/i-am-bee/beeai-labs/pull/283
 ```
 
 ## Getting IBM Github contributions
@@ -73,8 +80,17 @@ gha -d github.ibm.com -t <IBM_GITHUB_TOKEN>
 The utility can also gather PR data for a given repo and label using the following command:
 
 ```bash
-gha -p -r i-am-bee/beeai-framework --label python
+gha prs -r i-am-bee/beeai-framework --label python
 ```
+
+## Getting Issue Data
+
+The utility can also gather Issue data for a given repo and label using the following command:
+
+```bash
+gha issues -r i-am-bee/beeai-framework --label python
+```
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ To get contributions from IBM Github (github.ibm.com), you will need to use your
 gha -d github.ibm.com -t <IBM_GITHUB_TOKEN>
 ```
 
+## Getting PR Data
+
+The utility can also gather PR data for a given repo and label using the following command:
+
+```bash
+gha -p -r i-am-bee/beeai-framework --label python
+```
+
 ## Contributing
 
 To build the utility locally run the following command:

--- a/README.md
+++ b/README.md
@@ -68,5 +68,13 @@ To get contributions from IBM Github (github.ibm.com), you will need to use your
 gha -d github.ibm.com -t <IBM_GITHUB_TOKEN>
 ```
 
+## Contributing
+
+To build the utility locally run the following command:
+
+```bash
+go build -o gha
+```
+
 ## License
 This script is licensed under the Apache License, Version 2.0. You can find a copy of the license in the `LICENSE` file in the root directory of this repository.

--- a/cmd/issues.go
+++ b/cmd/issues.go
@@ -18,8 +18,9 @@ var issuesCmd = &cobra.Command{
 }
 
 func init() {
-	issuesCmd.PersistentFlags().StringVarP(&repo, "repo", "r", "i-am-bee/beeai-framework", "Github org/repo")
-	issuesCmd.PersistentFlags().StringArrayVarP(&labels, "label", "l", []string{"python"}, "Issue/PR label")
+	issuesCmd.PersistentFlags().StringVarP(&repo, "repo", "r", "", "Github org/repo")
+	issuesCmd.PersistentFlags().StringArrayVarP(&labels, "label", "l", []string{}, "Issue/PR label")
 	issuesCmd.PersistentFlags().StringVarP(&output, "output", "o", "", "Output Filename (JSON)")
+	issuesCmd.MarkPersistentFlagRequired("repo")
 	rootCmd.AddCommand(issuesCmd)
 }

--- a/cmd/issues.go
+++ b/cmd/issues.go
@@ -1,0 +1,25 @@
+/*
+Copyright © 2025 psschwei (paul@paulschweigert.com)
+*/
+package cmd
+
+import (
+	"github-activity/pkg/github"
+	"github.com/spf13/cobra"
+)
+
+var issuesCmd = &cobra.Command{
+	Use:   "issues",
+	Short: "Get GitHub Issues data",
+	Long:  `Get GitHub Issues data for a given repo and labels`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return github.GetPRData(domain, token, repo, output, labels)
+	},
+}
+
+func init() {
+	issuesCmd.PersistentFlags().StringVarP(&repo, "repo", "r", "i-am-bee/beeai-framework", "Github org/repo")
+	issuesCmd.PersistentFlags().StringArrayVarP(&labels, "label", "l", []string{"python"}, "Issue/PR label")
+	issuesCmd.PersistentFlags().StringVarP(&output, "output", "o", "", "Output Filename")
+	rootCmd.AddCommand(issuesCmd)
+}

--- a/cmd/issues.go
+++ b/cmd/issues.go
@@ -13,13 +13,13 @@ var issuesCmd = &cobra.Command{
 	Short: "Get GitHub Issues data",
 	Long:  `Get GitHub Issues data for a given repo and labels`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return github.GetPRData(domain, token, repo, output, labels)
+		return github.GetIssuesData(domain, token, repo, output, enddate, startdate, labels)
 	},
 }
 
 func init() {
 	issuesCmd.PersistentFlags().StringVarP(&repo, "repo", "r", "i-am-bee/beeai-framework", "Github org/repo")
 	issuesCmd.PersistentFlags().StringArrayVarP(&labels, "label", "l", []string{"python"}, "Issue/PR label")
-	issuesCmd.PersistentFlags().StringVarP(&output, "output", "o", "", "Output Filename")
+	issuesCmd.PersistentFlags().StringVarP(&output, "output", "o", "", "Output Filename (JSON)")
 	rootCmd.AddCommand(issuesCmd)
 }

--- a/cmd/prs.go
+++ b/cmd/prs.go
@@ -1,0 +1,25 @@
+/*
+Copyright © 2025 psschwei (paul@paulschweigert.com)
+*/
+package cmd
+
+import (
+	"github-activity/pkg/github"
+	"github.com/spf13/cobra"
+)
+
+var prsCmd = &cobra.Command{
+	Use:   "prs",
+	Short: "Get PR data",
+	Long:  `Get PR data for a given repo and labels`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return github.GetPRData(domain, token, repo, output, labels)
+	},
+}
+
+func init() {
+	prsCmd.PersistentFlags().StringVarP(&repo, "repo", "r", "i-am-bee/beeai-framework", "Github org/repo")
+	prsCmd.PersistentFlags().StringArrayVarP(&labels, "label", "l", []string{"python"}, "Issue/PR label")
+	prsCmd.PersistentFlags().StringVarP(&output, "output", "o", "", "Output Filename")
+	rootCmd.AddCommand(prsCmd)
+}

--- a/cmd/prs.go
+++ b/cmd/prs.go
@@ -18,8 +18,9 @@ var prsCmd = &cobra.Command{
 }
 
 func init() {
-	prsCmd.PersistentFlags().StringVarP(&repo, "repo", "r", "i-am-bee/beeai-framework", "Github org/repo")
-	prsCmd.PersistentFlags().StringArrayVarP(&labels, "label", "l", []string{"python"}, "Issue/PR label")
+	prsCmd.PersistentFlags().StringVarP(&repo, "repo", "r", "", "Github org/repo")
+	prsCmd.PersistentFlags().StringArrayVarP(&labels, "label", "l", []string{}, "Issue/PR label")
 	prsCmd.PersistentFlags().StringVarP(&output, "output", "o", "", "Output Filename (JSON)")
+	prsCmd.MarkPersistentFlagRequired("repo")
 	rootCmd.AddCommand(prsCmd)
 }

--- a/cmd/prs.go
+++ b/cmd/prs.go
@@ -13,13 +13,13 @@ var prsCmd = &cobra.Command{
 	Short: "Get PR data",
 	Long:  `Get PR data for a given repo and labels`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return github.GetPRData(domain, token, repo, output, labels)
+		return github.GetPRData(domain, token, repo, output, enddate, startdate, labels,)
 	},
 }
 
 func init() {
 	prsCmd.PersistentFlags().StringVarP(&repo, "repo", "r", "i-am-bee/beeai-framework", "Github org/repo")
 	prsCmd.PersistentFlags().StringArrayVarP(&labels, "label", "l", []string{"python"}, "Issue/PR label")
-	prsCmd.PersistentFlags().StringVarP(&output, "output", "o", "", "Output Filename")
+	prsCmd.PersistentFlags().StringVarP(&output, "output", "o", "", "Output Filename (JSON)")
 	rootCmd.AddCommand(prsCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,8 +6,8 @@ package cmd
 import (
 	"os"
 
-	"github.com/psschwei/github-activity/pkg/github"
-	"github.com/psschwei/github-activity/pkg/utils"
+	"github-activity/pkg/github"
+	"github-activity/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -20,12 +20,20 @@ var lastweek bool
 var thisweek bool
 var today bool
 
+var repo string
+var label string
+var prs bool
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "github-activity",
 	Short: "Get your Github activity",
 	Long:  `Get PRs, reviews, and issues created during a specific time interval.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if prs {
+			return github.GetPRData(domain, token, repo, label)
+		}
+
 		if lastweek == true {
 			startdate, enddate = utils.GetLastWeekDates()
 		} else if thisweek == true {
@@ -56,4 +64,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&today, "today", "n", false, "Collect activities for today")
 	rootCmd.PersistentFlags().StringVarP(&username, "user", "u", utils.GetCurrentUsername(), "Username")
 	rootCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Github Personal Access Token (default `$GITHUB_TOKEN`)")
+	rootCmd.PersistentFlags().BoolVarP(&prs, "prs", "p", false, "Return PR data")
+	rootCmd.PersistentFlags().StringVarP(&repo, "repo", "r", "i-am-bee/beeai-framework", "Github org/repo")
+	rootCmd.PersistentFlags().StringVar(&label, "label", "python", "Issue/PR label")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,8 +21,8 @@ var thisweek bool
 var today bool
 
 var repo string
-var label string
-var prs bool
+var labels []string
+var output string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -30,10 +30,6 @@ var rootCmd = &cobra.Command{
 	Short: "Get your Github activity",
 	Long:  `Get PRs, reviews, and issues created during a specific time interval.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if prs {
-			return github.GetPRData(domain, token, repo, label)
-		}
-
 		if lastweek == true {
 			startdate, enddate = utils.GetLastWeekDates()
 		} else if thisweek == true {
@@ -57,14 +53,11 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&domain, "domain", "d", "github.com", "Github domain")
-	rootCmd.PersistentFlags().StringVarP(&startdate, "start", "s", utils.GetDefaultStartDate(), "Collect activities starting on this date")
-	rootCmd.PersistentFlags().StringVarP(&enddate, "end", "e", utils.GetDefaultEndDate(), "Collect activities up to this date")
-	rootCmd.PersistentFlags().BoolVarP(&lastweek, "last-week", "l", false, "Collect activities for last week (last week Monday to last week Friday")
-	rootCmd.PersistentFlags().BoolVarP(&thisweek, "this-week", "w", false, "Collect activities for this week (Monday to Friday")
-	rootCmd.PersistentFlags().BoolVarP(&today, "today", "n", false, "Collect activities for today")
+	rootCmd.Flags().StringVarP(&startdate, "start", "s", utils.GetDefaultStartDate(), "Collect activities starting on this date")
+	rootCmd.Flags().StringVarP(&enddate, "end", "e", utils.GetDefaultEndDate(), "Collect activities up to this date")
+	rootCmd.Flags().BoolVarP(&lastweek, "last-week", "l", false, "Collect activities for last week (last week Monday to last week Friday)")
+	rootCmd.Flags().BoolVarP(&thisweek, "this-week", "w", false, "Collect activities for this week (Monday to Friday)")
+	rootCmd.Flags().BoolVarP(&today, "today", "n", false, "Collect activities for today")
 	rootCmd.PersistentFlags().StringVarP(&username, "user", "u", utils.GetCurrentUsername(), "Username")
 	rootCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Github Personal Access Token (default `$GITHUB_TOKEN`)")
-	rootCmd.PersistentFlags().BoolVarP(&prs, "prs", "p", false, "Return PR data")
-	rootCmd.PersistentFlags().StringVarP(&repo, "repo", "r", "i-am-bee/beeai-framework", "Github org/repo")
-	rootCmd.PersistentFlags().StringVar(&label, "label", "python", "Issue/PR label")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,8 +53,8 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&domain, "domain", "d", "github.com", "Github domain")
-	rootCmd.Flags().StringVarP(&startdate, "start", "s", utils.GetDefaultStartDate(), "Collect activities starting on this date")
-	rootCmd.Flags().StringVarP(&enddate, "end", "e", utils.GetDefaultEndDate(), "Collect activities up to this date")
+	rootCmd.PersistentFlags().StringVarP(&startdate, "start", "s", utils.GetDefaultStartDate(), "Collect activities starting on this date")
+	rootCmd.PersistentFlags().StringVarP(&enddate, "end", "e", utils.GetDefaultEndDate(), "Collect activities up to this date")
 	rootCmd.Flags().BoolVarP(&lastweek, "last-week", "l", false, "Collect activities for last week (last week Monday to last week Friday)")
 	rootCmd.Flags().BoolVarP(&thisweek, "this-week", "w", false, "Collect activities for this week (Monday to Friday)")
 	rootCmd.Flags().BoolVarP(&today, "today", "n", false, "Collect activities for today")

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/psschwei/github-activity
+module github-activity
 
 go 1.23.4
 

--- a/main.go
+++ b/main.go
@@ -1,10 +1,9 @@
 /*
 Copyright © 2025 NAME HERE <EMAIL ADDRESS>
-
 */
 package main
 
-import "github.com/psschwei/github-activity/cmd"
+import "github-activity/cmd"
 
 func main() {
 	cmd.Execute()

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/psschwei/github-activity/pkg/utils"
+	"github-activity/pkg/utils"
 )
 
 func GetGithubActivity(domain, startDate, endDate, username, token string) error {
@@ -39,4 +39,43 @@ func GetGithubActivity(domain, startDate, endDate, username, token string) error
 	printActivityOutput(&userActivity)
 
 	return nil
+}
+
+func GetPRData(domain, token, repo, label string) error {
+	var prData gitHubPrs
+	var nextPage gitHubPrs
+
+	cursor := ""
+
+	url := getGithubUrl(domain)
+
+	if token == "" {
+		token = os.Getenv("GITHUB_TOKEN")
+	}
+	if token == "" {
+		return errors.New("no Github token specified")
+	}
+
+	prQuery := getGithubPrsQuery(repo, label, cursor)
+
+	if err := queryGithubApiPrs(url, prQuery, token, &nextPage); err != nil {
+		return err
+	}
+
+	prData = nextPage
+
+	for nextPage.Data.Search.PageInfo.HasNextPage {
+		prQuery := getGithubPrsQuery(repo, label, nextPage.Data.Search.PageInfo.EndCursor)
+
+		if err := queryGithubApiPrs(url, prQuery, token, &nextPage); err != nil {
+			return err
+		}
+		prData.Data.Search.Edges = append(prData.Data.Search.Edges, nextPage.Data.Search.Edges...)
+		prData.Data.Search.PageInfo = nextPage.Data.Search.PageInfo
+	}
+
+	printPrDataOutput(&prData)
+
+	return nil
+
 }

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -41,7 +41,7 @@ func GetGithubActivity(domain, startDate, endDate, username, token string) error
 	return nil
 }
 
-func GetPRData(domain, token, repo, label string) error {
+func GetPRData(domain, token, repo, output string, labels []string) error {
 	var prData gitHubPrs
 	var nextPage gitHubPrs
 
@@ -56,7 +56,7 @@ func GetPRData(domain, token, repo, label string) error {
 		return errors.New("no Github token specified")
 	}
 
-	prQuery := getGithubPrsQuery(repo, label, cursor)
+	prQuery := getGithubPrsQuery(repo, labels, cursor)
 
 	if err := queryGithubApiPrs(url, prQuery, token, &nextPage); err != nil {
 		return err
@@ -65,7 +65,7 @@ func GetPRData(domain, token, repo, label string) error {
 	prData = nextPage
 
 	for nextPage.Data.Search.PageInfo.HasNextPage {
-		prQuery := getGithubPrsQuery(repo, label, nextPage.Data.Search.PageInfo.EndCursor)
+		prQuery := getGithubPrsQuery(repo, labels, nextPage.Data.Search.PageInfo.EndCursor)
 
 		if err := queryGithubApiPrs(url, prQuery, token, &nextPage); err != nil {
 			return err
@@ -74,7 +74,7 @@ func GetPRData(domain, token, repo, label string) error {
 		prData.Data.Search.PageInfo = nextPage.Data.Search.PageInfo
 	}
 
-	printPrDataOutput(&prData)
+	printPrDataOutput(&prData, output)
 
 	return nil
 

--- a/pkg/github/helpers.go
+++ b/pkg/github/helpers.go
@@ -78,7 +78,7 @@ func getGithubQuery(u, s, e string) string {
 func getGithubPrsQuery(repo, label, cursor string) string {
 	labelStr := ""
 	if label != "" {
-		labelStr = fmt.Sprintf("label:%s", label)
+		labelStr = fmt.Sprintf("label:\\\"%s\\\"", label)
 	}
 
 	prQuery := fmt.Sprintf(`

--- a/pkg/github/helpers.go
+++ b/pkg/github/helpers.go
@@ -75,6 +75,168 @@ func getGithubQuery(u, s, e string) string {
 	return query
 }
 
+func getGithubPrsQuery(repo, label, cursor string) string {
+	labelStr := ""
+	if label != "" {
+		labelStr = fmt.Sprintf("label:%s", label)
+	}
+
+	prQuery := fmt.Sprintf(`
+	query {
+		search(query: "repo:%s is:pr %s is:closed", type: ISSUE, first: 100 , after: "%s") {
+			issueCount
+			edges {
+				node {
+					... on PullRequest {
+						id
+						number
+						url
+						title
+						state
+						labels(first: 10){
+							edges {
+								node {
+									name
+								}
+							}
+						}
+						comments{
+							totalCount
+						}
+						createdAt
+						updatedAt
+						closedAt
+						mergedAt
+						baseRefName
+						changedFiles
+						additions
+						deletions
+						isDraft
+						commits(first: 100) {
+							nodes {
+								commit {
+									committedDate
+								}
+							}
+						}
+						repository{
+							id
+						}
+						author {
+							login
+							url
+						}
+						assignees(first: 5){
+							edges {
+								node {
+									login
+									url
+								}
+							}
+						}
+						closingIssuesReferences(first: 5){
+							edges {
+								node {
+									number
+									url
+								}
+							}
+						}
+						participants(first: 10){
+							edges {
+								node {
+									login
+									url
+								}
+							}
+						}
+					}
+				}
+			}
+			pageInfo {
+					hasNextPage
+					endCursor
+			}
+		}
+	}`, repo, labelStr, cursor)
+
+	return prQuery
+}
+
+type gitHubPrs struct {
+	Data struct {
+		Search struct {
+			IssueCount int `json:"issueCount"`
+			Edges      []struct {
+				Node Node `json:"node"`
+			} `json:"edges"`
+			PageInfo struct {
+				HasNextPage bool   `json:"hasNextPage"`
+				EndCursor   string `json:"endCursor"`
+			} `json:"pageInfo"`
+		} `json:"search"`
+	} `json:"data"`
+}
+
+type Node struct {
+	ID     string `json:"id"`
+	Number int    `json:"number"`
+	URL    string `json:"url"`
+	Title  string `json:"title"`
+	State  string `json:"state"`
+	Labels struct {
+		Edges []struct {
+			Node Label `json:"node"`
+		} `json:"edges"`
+	} `json:"labels"`
+	Comments struct {
+		TotalCount int `json:"totalCount"`
+	} `json:"comments"`
+	CreatedAt    string `json:"createdAt"`
+	UpdatedAt    string `json:"updatedAt"`
+	ClosedAt     string `json:"closedAt"`
+	MergedAt     string `json:"mergedAt"`
+	BaseRefName  string `json:"baseRefName"`
+	ChangedFiles int    `json:"changedFiles"`
+	Additions    int    `json:"additions"`
+	Deletions    int    `json:"deletions"`
+	IsDraft      bool   `json:"isDraft"`
+	Commits      struct {
+		Nodes []struct {
+			Commit struct {
+				CommittedDate string `json:"committedDate"`
+			} `json:"commit"`
+		} `json:"nodes"`
+	} `json:"commits"`
+	Repository struct {
+		ID string `json:"id"`
+	} `json:"repository"`
+	Author struct {
+		Login string `json:"login"`
+		URL   string `json:"url"`
+	} `json:"author"`
+	Assignees struct {
+		Edges []interface{} `json:"edges"`
+	} `json:"assignees"`
+	ClosingIssuesReferences struct {
+		Edges []interface{} `json:"edges"`
+	} `json:"closingIssuesReferences"`
+	Participants struct {
+		Edges []struct {
+			Node Participant `json:"node"`
+		} `json:"edges"`
+	} `json:"participants"`
+}
+
+type Label struct {
+	Name string `json:"name"`
+}
+
+type Participant struct {
+	Login string `json:"login"`
+	URL   string `json:"url"`
+}
+
 // Assisted by watsonx Code Assistant
 type gitHubActivity struct {
 	Data struct {
@@ -127,7 +289,7 @@ type gitHubActivity struct {
 	}
 }
 
-func queryGithubApi(url, query, token string, userActivity *gitHubActivity) error {
+func callGithubApi(url, query, token string) (*http.Response, error) {
 	payload := map[string]string{"query": query}
 	payloadBytes, _ := json.Marshal(payload)
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(payloadBytes))
@@ -140,12 +302,21 @@ func queryGithubApi(url, query, token string, userActivity *gitHubActivity) erro
 
 	res, err := client.Do(req)
 	if err != nil {
-		fmt.Errorf("unable to query github api")
-		return err
+		return res, fmt.Errorf("unable to query github api")
 	}
 
 	if res.StatusCode != 200 {
-		return errors.New("error querying github api: " + res.Status)
+		return res, errors.New("error querying github api: " + res.Status)
+	}
+
+	return res, err
+
+}
+
+func queryGithubApi(url, query, token string, userActivity *gitHubActivity) error {
+	res, err := callGithubApi(url, query, token)
+	if err != nil {
+		return err
 	}
 
 	resBody, _ := io.ReadAll(res.Body)
@@ -157,6 +328,31 @@ func queryGithubApi(url, query, token string, userActivity *gitHubActivity) erro
 
 	return nil
 
+}
+
+func queryGithubApiPrs(url, query, token string, prData *gitHubPrs) error {
+	res, err := callGithubApi(url, query, token)
+	if err != nil {
+		return err
+	}
+
+	resBody, _ := io.ReadAll(res.Body)
+
+	if err = json.Unmarshal(resBody, &prData); err != nil {
+		fmt.Println("cannot unmarshal json")
+		return err
+	}
+
+	return nil
+
+}
+
+func printPrDataOutput(prData *gitHubPrs) {
+	jsonPretty, err := json.MarshalIndent(prData, "", "    ")
+	if err != nil {
+		fmt.Println("Error marshaling JSON: ", err)
+	}
+	fmt.Println(string(jsonPretty))
 }
 
 func printActivityOutput(userActivity *gitHubActivity) {

--- a/pkg/github/helpers.go
+++ b/pkg/github/helpers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"time"
 )
 
@@ -73,168 +74,6 @@ func getGithubQuery(u, s, e string) string {
     }`, u, s, e)
 
 	return query
-}
-
-func getGithubPrsQuery(repo, label, cursor string) string {
-	labelStr := ""
-	if label != "" {
-		labelStr = fmt.Sprintf("label:\\\"%s\\\"", label)
-	}
-
-	prQuery := fmt.Sprintf(`
-	query {
-		search(query: "repo:%s is:pr %s is:closed", type: ISSUE, first: 100 , after: "%s") {
-			issueCount
-			edges {
-				node {
-					... on PullRequest {
-						id
-						number
-						url
-						title
-						state
-						labels(first: 10){
-							edges {
-								node {
-									name
-								}
-							}
-						}
-						comments{
-							totalCount
-						}
-						createdAt
-						updatedAt
-						closedAt
-						mergedAt
-						baseRefName
-						changedFiles
-						additions
-						deletions
-						isDraft
-						commits(first: 100) {
-							nodes {
-								commit {
-									committedDate
-								}
-							}
-						}
-						repository{
-							id
-						}
-						author {
-							login
-							url
-						}
-						assignees(first: 5){
-							edges {
-								node {
-									login
-									url
-								}
-							}
-						}
-						closingIssuesReferences(first: 5){
-							edges {
-								node {
-									number
-									url
-								}
-							}
-						}
-						participants(first: 10){
-							edges {
-								node {
-									login
-									url
-								}
-							}
-						}
-					}
-				}
-			}
-			pageInfo {
-					hasNextPage
-					endCursor
-			}
-		}
-	}`, repo, labelStr, cursor)
-
-	return prQuery
-}
-
-type gitHubPrs struct {
-	Data struct {
-		Search struct {
-			IssueCount int `json:"issueCount"`
-			Edges      []struct {
-				Node Node `json:"node"`
-			} `json:"edges"`
-			PageInfo struct {
-				HasNextPage bool   `json:"hasNextPage"`
-				EndCursor   string `json:"endCursor"`
-			} `json:"pageInfo"`
-		} `json:"search"`
-	} `json:"data"`
-}
-
-type Node struct {
-	ID     string `json:"id"`
-	Number int    `json:"number"`
-	URL    string `json:"url"`
-	Title  string `json:"title"`
-	State  string `json:"state"`
-	Labels struct {
-		Edges []struct {
-			Node Label `json:"node"`
-		} `json:"edges"`
-	} `json:"labels"`
-	Comments struct {
-		TotalCount int `json:"totalCount"`
-	} `json:"comments"`
-	CreatedAt    string `json:"createdAt"`
-	UpdatedAt    string `json:"updatedAt"`
-	ClosedAt     string `json:"closedAt"`
-	MergedAt     string `json:"mergedAt"`
-	BaseRefName  string `json:"baseRefName"`
-	ChangedFiles int    `json:"changedFiles"`
-	Additions    int    `json:"additions"`
-	Deletions    int    `json:"deletions"`
-	IsDraft      bool   `json:"isDraft"`
-	Commits      struct {
-		Nodes []struct {
-			Commit struct {
-				CommittedDate string `json:"committedDate"`
-			} `json:"commit"`
-		} `json:"nodes"`
-	} `json:"commits"`
-	Repository struct {
-		ID string `json:"id"`
-	} `json:"repository"`
-	Author struct {
-		Login string `json:"login"`
-		URL   string `json:"url"`
-	} `json:"author"`
-	Assignees struct {
-		Edges []interface{} `json:"edges"`
-	} `json:"assignees"`
-	ClosingIssuesReferences struct {
-		Edges []interface{} `json:"edges"`
-	} `json:"closingIssuesReferences"`
-	Participants struct {
-		Edges []struct {
-			Node Participant `json:"node"`
-		} `json:"edges"`
-	} `json:"participants"`
-}
-
-type Label struct {
-	Name string `json:"name"`
-}
-
-type Participant struct {
-	Login string `json:"login"`
-	URL   string `json:"url"`
 }
 
 // Assisted by watsonx Code Assistant
@@ -330,31 +169,6 @@ func queryGithubApi(url, query, token string, userActivity *gitHubActivity) erro
 
 }
 
-func queryGithubApiPrs(url, query, token string, prData *gitHubPrs) error {
-	res, err := callGithubApi(url, query, token)
-	if err != nil {
-		return err
-	}
-
-	resBody, _ := io.ReadAll(res.Body)
-
-	if err = json.Unmarshal(resBody, &prData); err != nil {
-		fmt.Println("cannot unmarshal json")
-		return err
-	}
-
-	return nil
-
-}
-
-func printPrDataOutput(prData *gitHubPrs) {
-	jsonPretty, err := json.MarshalIndent(prData, "", "    ")
-	if err != nil {
-		fmt.Println("Error marshaling JSON: ", err)
-	}
-	fmt.Println(string(jsonPretty))
-}
-
 func printActivityOutput(userActivity *gitHubActivity) {
 	data := userActivity.Data.User.ContributionsCollection
 
@@ -444,4 +258,18 @@ func printActivityOutput(userActivity *gitHubActivity) {
 	}
 
 	fmt.Printf(fmt.Sprintf("\nTotals: PRs(%d) Reviews(%d) Issues(%d)", len(data.PullRequestContributions.Edges), len(data.PullRequestReviewContributions.Edges), len(data.IssueContributions.Edges)))
+}
+
+func printToFile(str, file string) error {
+	f, err := os.Create(file)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(str); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/github/prshelpers.go
+++ b/pkg/github/prshelpers.go
@@ -27,7 +27,7 @@ func getGithubPrsQuery(repo string, labels []string, endDate string, startDate s
 
 	prQuery := fmt.Sprintf(`
 	query {
-		search(query: "repo:%s is:pr %s %s is:closed", type: ISSUE, first: 100 , after: "%s") {
+		search(query: "repo:%s is:pr %s %s ", type: ISSUE, first: 100 , after: "%s") {
 			issueCount
 			edges {
 				node {

--- a/pkg/github/prshelpers.go
+++ b/pkg/github/prshelpers.go
@@ -1,0 +1,199 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+func getGithubPrsQuery(repo string, labels []string, cursor string) string {
+	labelStr := ""
+	for _, label := range labels {
+		if label != "" {
+			labelStr += fmt.Sprintf("label:\\\"%s\\\" ", label)
+		}
+	}
+
+	prQuery := fmt.Sprintf(`
+	query {
+		search(query: "repo:%s is:pr %s is:closed", type: ISSUE, first: 100 , after: "%s") {
+			issueCount
+			edges {
+				node {
+					... on PullRequest {
+						id
+						number
+						url
+						title
+						state
+						labels(first: 10){
+							edges {
+								node {
+									name
+								}
+							}
+						}
+						comments{
+							totalCount
+						}
+						createdAt
+						updatedAt
+						closedAt
+						mergedAt
+						baseRefName
+						changedFiles
+						additions
+						deletions
+						isDraft
+						commits(first: 100) {
+							nodes {
+								commit {
+									committedDate
+								}
+							}
+						}
+						repository{
+							id
+						}
+						author {
+							login
+							url
+						}
+						assignees(first: 5){
+							edges {
+								node {
+									login
+									url
+								}
+							}
+						}
+						closingIssuesReferences(first: 5){
+							edges {
+								node {
+									number
+									url
+								}
+							}
+						}
+						participants(first: 10){
+							edges {
+								node {
+									login
+									url
+								}
+							}
+						}
+					}
+				}
+			}
+			pageInfo {
+					hasNextPage
+					endCursor
+			}
+		}
+	}`, repo, labelStr, cursor)
+	
+	return prQuery
+}
+
+type gitHubPrs struct {
+	Data struct {
+		Search struct {
+			IssueCount int `json:"issueCount"`
+			Edges      []struct {
+				Node Node `json:"node"`
+			} `json:"edges"`
+			PageInfo struct {
+				HasNextPage bool   `json:"hasNextPage"`
+				EndCursor   string `json:"endCursor"`
+			} `json:"pageInfo"`
+		} `json:"search"`
+	} `json:"data"`
+}
+
+type Node struct {
+	ID     string `json:"id"`
+	Number int    `json:"number"`
+	URL    string `json:"url"`
+	Title  string `json:"title"`
+	State  string `json:"state"`
+	Labels struct {
+		Edges []struct {
+			Node Label `json:"node"`
+		} `json:"edges"`
+	} `json:"labels"`
+	Comments struct {
+		TotalCount int `json:"totalCount"`
+	} `json:"comments"`
+	CreatedAt    string `json:"createdAt"`
+	UpdatedAt    string `json:"updatedAt"`
+	ClosedAt     string `json:"closedAt"`
+	MergedAt     string `json:"mergedAt"`
+	BaseRefName  string `json:"baseRefName"`
+	ChangedFiles int    `json:"changedFiles"`
+	Additions    int    `json:"additions"`
+	Deletions    int    `json:"deletions"`
+	IsDraft      bool   `json:"isDraft"`
+	Commits      struct {
+		Nodes []struct {
+			Commit struct {
+				CommittedDate string `json:"committedDate"`
+			} `json:"commit"`
+		} `json:"nodes"`
+	} `json:"commits"`
+	Repository struct {
+		ID string `json:"id"`
+	} `json:"repository"`
+	Author struct {
+		Login string `json:"login"`
+		URL   string `json:"url"`
+	} `json:"author"`
+	Assignees struct {
+		Edges []interface{} `json:"edges"`
+	} `json:"assignees"`
+	ClosingIssuesReferences struct {
+		Edges []interface{} `json:"edges"`
+	} `json:"closingIssuesReferences"`
+	Participants struct {
+		Edges []struct {
+			Node Participant `json:"node"`
+		} `json:"edges"`
+	} `json:"participants"`
+}
+
+type Label struct {
+	Name string `json:"name"`
+}
+
+type Participant struct {
+	Login string `json:"login"`
+	URL   string `json:"url"`
+}
+
+func queryGithubApiPrs(url, query, token string, prData *gitHubPrs) error {
+	res, err := callGithubApi(url, query, token)
+	if err != nil {
+		return err
+	}
+
+	resBody, _ := io.ReadAll(res.Body)
+
+	if err = json.Unmarshal(resBody, &prData); err != nil {
+		fmt.Println("cannot unmarshal json")
+		return err
+	}
+
+	return nil
+
+}
+
+func printPrDataOutput(prData *gitHubPrs, output string) {
+	jsonPretty, err := json.MarshalIndent(prData, "", "    ")
+	if err != nil {
+		fmt.Println("Error marshaling JSON: ", err)
+	}
+
+	if err = printToFile(string(jsonPretty), output); err != nil {
+		fmt.Println(string(jsonPretty))
+	}
+}


### PR DESCRIPTION
Adds `prs` and `issues` commands that return json objects with pr and issue data.

for ref:
```
$ ./gha prs --help
Get PR data for a given repo and labels

Usage:
  github-activity prs [flags]

Flags:
  -h, --help                help for prs
  -l, --label stringArray   Issue/PR label (default [python])
  -o, --output string       Output Filename
  -r, --repo string         Github org/repo (default "i-am-bee/beeai-framework")

Global Flags:
  -d, --domain string         Github domain (default "github.com")
  -e, --end string            Collect activities up to this date (default "2025-06-06")
  -s, --start string          Collect activities starting on this date (default "2025-05-29")
  -t, --token $GITHUB_TOKEN   Github Personal Access Token (default $GITHUB_TOKEN)
  -u, --user string           Username (default "ajbozarth")
```