### PR TITLE
Update GH CLI script

### DIFF
--- a/weekly-activity.sh
+++ b/weekly-activity.sh
@@ -6,8 +6,8 @@ which gdate > /dev/null && date_cmd="gdate" || date_cmd="date"
 starting_date=$($date_cmd -dlast-monday +"%Y-%m-%d")
 gh_search_flags="--updated >=$starting_date --json repository,title,url"
 
-echo "PRs ($(gh search prs $gh_search_flags | jq 'length'))"
-gh search prs $gh_search_flags --template '{{ range . }}{{ printf "* [%s] %s: %s\n" .repository.nameWithOwner .title .url }}{{ end }}'
+echo "PRs ($(gh search prs --author @me $gh_search_flags | jq 'length'))"
+gh search prs --author @me $gh_search_flags --template '{{ range . }}{{ printf "* [%s] %s: %s\n" .repository.nameWithOwner .title .url }}{{ end }}'
 
 echo "Reviews ($(gh search prs --reviewed-by @me $gh_search_flags | jq 'length'))"
 gh search prs --reviewed-by @me $gh_search_flags --template '{{ range . }}{{ printf "* [%s] %s: %s\n" .repository.nameWithOwner .title .url }}{{ end }}'

--- a/weekly-activity.sh
+++ b/weekly-activity.sh
@@ -12,6 +12,6 @@ gh search prs --author @me $gh_search_flags --template '{{ range . }}{{ printf "
 echo "Reviews ($(gh search prs --reviewed-by @me $gh_search_flags | jq 'length'))"
 gh search prs --reviewed-by @me $gh_search_flags --template '{{ range . }}{{ printf "* [%s] %s: %s\n" .repository.nameWithOwner .title .url }}{{ end }}'
 
-echo "Issues ($(gh search prs $gh_search_flags | jq 'length'))"
-gh search issues $gh_search_flags --template '{{ range . }}{{ printf "* [%s] %s: %s\n" .repository.nameWithOwner .title .url }}{{ end }}'
+echo "Issues ($(gh search issues --author @me $gh_search_flags | jq 'length'))"
+gh search issues --author @me $gh_search_flags --template '{{ range . }}{{ printf "* [%s] %s: %s\n" .repository.nameWithOwner .title .url }}{{ end }}'
 

--- a/weekly-activity.sh
+++ b/weekly-activity.sh
@@ -1,13 +1,17 @@
 #! /bin/bash
 set -e
 
-starting_date=$(date -d "7 days ago" +"%Y-%m-%d")
+which gdate > /dev/null && date_cmd="gdate" || date_cmd="date"
 
-# PRs
-gh search prs --author "@me" --created ">=$starting_date"
+starting_date=$($date_cmd -dlast-monday +"%Y-%m-%d")
+gh_search_flags="--author @me --updated >=$starting_date --json repository,title,url"
 
-# Reviews
-gh search prs --reviewed-by "@me" --created ">=$starting_date"
+echo "PRs ($(gh search prs $gh_search_flags | jq 'length'))"
+gh search prs $gh_search_flags --template '{{ range . }}{{ printf "* [%s] %s: %s\n" .repository.nameWithOwner .title .url }}{{ end }}'
 
-# Issues
-gh search issues --author "@me" --created ">=$starting_date"
+echo "Reviews ($(gh search prs $gh_search_flags | jq 'length'))"
+gh search prs $gh_search_flags --template '{{ range . }}{{ printf "* [%s] %s: %s\n" .repository.nameWithOwner .title .url }}{{ end }}'
+
+echo "Issues ($(gh search prs $gh_search_flags | jq 'length'))"
+gh search issues $gh_search_flags --template '{{ range . }}{{ printf "* [%s] %s: %s\n" .repository.nameWithOwner .title .url }}{{ end }}'
+

--- a/weekly-activity.sh
+++ b/weekly-activity.sh
@@ -4,7 +4,7 @@ set -e
 which gdate > /dev/null && date_cmd="gdate" || date_cmd="date"
 
 starting_date=$($date_cmd -dlast-monday +"%Y-%m-%d")
-gh_search_flags="--author @me --updated >=$starting_date --json repository,title,url"
+gh_search_flags="--updated >=$starting_date --json repository,title,url"
 
 echo "PRs ($(gh search prs $gh_search_flags | jq 'length'))"
 gh search prs $gh_search_flags --template '{{ range . }}{{ printf "* [%s] %s: %s\n" .repository.nameWithOwner .title .url }}{{ end }}'

--- a/weekly-activity.sh
+++ b/weekly-activity.sh
@@ -9,8 +9,8 @@ gh_search_flags="--updated >=$starting_date --json repository,title,url"
 echo "PRs ($(gh search prs $gh_search_flags | jq 'length'))"
 gh search prs $gh_search_flags --template '{{ range . }}{{ printf "* [%s] %s: %s\n" .repository.nameWithOwner .title .url }}{{ end }}'
 
-echo "Reviews ($(gh search prs $gh_search_flags | jq 'length'))"
-gh search prs $gh_search_flags --template '{{ range . }}{{ printf "* [%s] %s: %s\n" .repository.nameWithOwner .title .url }}{{ end }}'
+echo "Reviews ($(gh search prs --reviewed-by @me $gh_search_flags | jq 'length'))"
+gh search prs --reviewed-by @me $gh_search_flags --template '{{ range . }}{{ printf "* [%s] %s: %s\n" .repository.nameWithOwner .title .url }}{{ end }}'
 
 echo "Issues ($(gh search prs $gh_search_flags | jq 'length'))"
 gh search issues $gh_search_flags --template '{{ range . }}{{ printf "* [%s] %s: %s\n" .repository.nameWithOwner .title .url }}{{ end }}'


### PR DESCRIPTION
Updated `weekly-activity.sh` to better replicate the current state of `github-activity`

comparison of the two outputs:

```
$ ./gha
github.com activity for ajbozarth between 2025-06-02T00:00:00Z and 2025-06-10T00:00:00Z:

Reviews (2)
* Qiskit/qiskit-code-assistant-jupyterlab
    - Increasing timeouts for generation to 15 seconds: https://github.com/Qiskit/qiskit-code-assistant-jupyterlab/pull/23
* i-am-bee/beeai-framework
    - fix: expose watsonx embedding model: https://github.com/i-am-bee/beeai-framework/pull/877

Totals: PRs(0) Reviews(2) Issues(0)
```

```
$ ./weekly-activity.sh 
PRs (1)
* [psschwei/github-activity] Add API for getting PR and Issue data: https://github.com/psschwei/github-activity/pull/4
Reviews (1)
* [psschwei/github-activity] Add API for getting PR and Issue data: https://github.com/psschwei/github-activity/pull/4
Issues (1)
* [i-am-bee/beeai-framework] Add GitHub workflow for automating Issue and PR labels: https://github.com/i-am-bee/beeai-framework/issues/798

```

The difference in content is because rather than running over the last week the GH CLI script runs over everything since the previous Monday (a better use case than what we have). In addition the current script can't find contribution to other users repos, only ones in orgs, when's the GH CLI can.